### PR TITLE
Blui 2923 migrate to updated image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,11 @@ workflows:
             - cypress_tests:
                    requires:
                        - build_project
-                   filters:
-                       branches:
-                           only:
-                               - master
-                               - dev
+                #    filters:
+                #        branches:
+                #            only:
+                #                - master
+                #                - dev
             - coverage_reports:
                 requires:
                     - build_project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,11 @@ workflows:
             - cypress_tests:
                    requires:
                        - build_project
-                #    filters:
-                #        branches:
-                #            only:
-                #                - master
-                #                - dev
+                   filters:
+                       branches:
+                           only:
+                               - master
+                               - dev
             - coverage_reports:
                 requires:
                     - build_project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,16 @@
 version: 2.1
 orbs:
     codecov: codecov/codecov@1.1.3
+    browser-tools: circleci/browser-tools@1.2.4
 jobs:
     build_project:
         working_directory: ~/angular-design-patterns
         docker:
-            - image: circleci/node:14.15.0-browsers
+            - image: cimg/node:14.19.0-browsers
         resource_class: large
         steps:
             - checkout
+            - browser-tools/install-browser-tools
             - restore_cache:
                 keys:
                     - v2-dependencies-{{ checksum "yarn.lock" }}
@@ -47,7 +49,7 @@ jobs:
     cypress_tests:
         working_directory: ~/angular-design-patterns
         docker:
-            - image: circleci/node:14.15.0-browsers
+            - image: cimg/node:14.19.0-browsers
         resource_class: large
         steps:
             - checkout
@@ -82,7 +84,7 @@ jobs:
     coverage_reports:
         working_directory: ~/angular-design-patterns
         docker:
-            - image: circleci/node:14.15.0-browsers
+            - image: cimg/node:14.19.0-browsers
         steps:
             - checkout
             - attach_workspace:


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Migrating to next-gen Convenience Images
- use browser-tools: circleci/browser-tools@1.2.4 orb
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- 
