### PR TITLE
mat-expansion-panel-header border match with divider color

### DIFF
--- a/src/app/pages/list/inline-local-actions/inline-local-actions.component.scss
+++ b/src/app/pages/list/inline-local-actions/inline-local-actions.component.scss
@@ -27,7 +27,7 @@ section.local-inline-actions-example {
                     margin-top: -8px;
                 }
                 &.mat-expanded {
-                    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+                    border-bottom: 1px solid rgba(map-get($blui-black, 500), 0.12);
                     .mat-expansion-indicator {
                         margin-top: 4px;
                     }

--- a/src/app/pages/list/status-list/status-list.component.scss
+++ b/src/app/pages/list/status-list/status-list.component.scss
@@ -45,7 +45,7 @@ section.list-section {
                     margin-top: -8px;
                 }
                 &.mat-expanded {
-                    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+                    border-bottom: 1px solid rgba(map-get($blui-black, 500), 0.12);
                     .mat-expansion-indicator {
                         margin-top: 4px;
                     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [175](brightlayer-ui/angular-themes#107) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- fix mat expansion header border for status list example
- fix mat expansion header border for inline actions example
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1481" alt="Screenshot 2022-04-06 at 5 22 08 PM" src="https://user-images.githubusercontent.com/10433274/161969811-e353c121-2286-4e83-a3f2-4c1cdbf1deef.png">
<img width="1433" alt="Screenshot 2022-04-06 at 5 22 24 PM" src="https://user-images.githubusercontent.com/10433274/161969818-1f425661-7919-4b4b-8920-3aa07f569d59.png">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- http://localhost:4200/lists/status-list
- http://localhost:4200/lists/inline-local-actions

inspect mat-expansion-panel-header and observe `border-bottom` css property .